### PR TITLE
Session 정보는 서버의 Memory에 저장되는데, 서버를 재 시작하면 Session 정보가 지워짐으로, 'connect…

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -5,6 +5,7 @@ import userRouter from "./router/userRouter";
 import videoRouter from "./router/videoRouter";
 import session from "express-session";
 import { localsMiddleware } from "./middlewares";
+import MongoStore from "connect-mongo";
 
 const app = express();
 app.use(logger("dev"));   
@@ -41,6 +42,10 @@ app.use(session({
     secret:"Hello",
     resave : true,
     saveUninitialized : true,
+    // ===========================================================================================
+    // Session Data를 저장하기 위해서 사용.. connect-Mongo 모듈을 사용, DB의 sessions가 자동 생성, 할당된다.
+    // ===========================================================================================
+    store: MongoStore.create({mongoUrl : "mongodb://127.0.0.1:27017/wetube"}), 
 }));
 
 app.use(localsMiddleware);


### PR DESCRIPTION
Session 정보는 서버의 Memory에 저장되는데, 서버를 재  
시작하면 Session 정보가 지워짐으로, 'connect-mongo'의 모듈을 사용하여 DB에 저장되게 하는 로직  
추가

1. server.js에 "MongoStore" Import connect-Mongo 선언
2. session Middleware에 connect-Mongo.create({connect-MongoURL}) 사용하여 DB에 저장되게 하는 구문 추가