### PR TITLE
소셜 로그인(Github)로 Redirect하는 로직이 HTML탬플릿 파일에 있던것을 Controller에서 변수화 해서 처…

### DIFF
--- a/src/controllers/userControllers.js
+++ b/src/controllers/userControllers.js
@@ -63,9 +63,21 @@ export const postLogin = async (req, res) => {
     return res.redirect("/");
 }
 
+export const startGithubLogin = (req, res) => {    
+    const baseUrl = `https://github.com/login/oauth/authorize`;
+    const config = {
+        clientId : "61c61c540b7a9c650293",
+        allow_singup : false,
+        scope : "read:user user:email",
+    };
+    const params = new URLSearchParams(config).toString();
+    const finalUrl = `${baseUrl}?${params}`;
+    return res.redirect(finalUrl);
+};
+
 export const edit = (req, res) => res.send("Edit User");
 export const remove = (req, res) => res.send("remove"); 
-export const logout = (req, res) => res.send("Log out"); 
+export const logout = (req, res) => res.send("Log out");  
 export const see = (req, res) => res.send("see User");   
 
 // 재 Commit을 위한 임시 주석

--- a/src/router/userRouter.js
+++ b/src/router/userRouter.js
@@ -1,11 +1,13 @@
 import express from "express";
-import {logout, edit, remove, see} from "../controllers/userControllers"
+import {logout, edit, remove, startGithubLogin, see} from "../controllers/userControllers"
 const userRouter = express.Router(); 
 
 userRouter.get("/logout", logout);
 userRouter.get("/edit", edit);
 userRouter.get("/remove", remove);
-userRouter.get(":id", see); 
+userRouter.get("/github/start", startGithubLogin); 
+
+userRouter.get("/:id", see);
     
 export default userRouter;
 

--- a/src/views/login.pug
+++ b/src/views/login.pug
@@ -8,7 +8,7 @@ block content
         input(name="password", type="password", required, placeholder="PassWord")
         input(type="submit",value="Login")
         br
-        a(href="https://github.com/login/oauth/authorize?client_id=61c61c540b7a9c650293") continue with Github &rarr;
+        a(href="https://github.com/login/oauth/authorize?client_id=61c61c540b7a9c650293&scope=user:email") continue with Github &rarr;
     hr
     div
         span 계정이 없으신가요? 지금 계정을 만드세요.


### PR DESCRIPTION
1. HTML탬플릿(login.pug)에서 소셜 로그인(깃) 하던 ULR을 컨트롤러 URL로 변경
2. Router에 users/github 소셜 로그인 라우터 추가
3. Controller에 (2)번 라우터의 후 처리를 담당하는 startGithubLogin 메소드 추가
    => 상기 메소드는 config정보를 가지고 git소셜 로그인으로 redirect합니다.

강의 12분부터 추가 작업 진행해야 합니다.